### PR TITLE
Improve loan endpoints

### DIFF
--- a/src/main/java/com/example/biblioteca_spring/controller/BibliotecaController.java
+++ b/src/main/java/com/example/biblioteca_spring/controller/BibliotecaController.java
@@ -3,7 +3,10 @@ package com.example.biblioteca_spring.controller;
 import com.example.biblioteca_spring.model.Livro;
 import com.example.biblioteca_spring.repository.LivroRepository;
 import com.example.biblioteca_spring.service.EmprestimoService;
+import com.example.biblioteca_spring.service.EmprestimoStatus;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,12 +27,36 @@ public class BibliotecaController {
     }
 
     @GetMapping("/livros")
-    public List<Livro> listarLivrosDisponiveis() {
-        return livroRepository.findByDisponivelTrue();
+    public ResponseEntity<List<Livro>> listarLivrosDisponiveis() {
+        List<Livro> livros = livroRepository.findByDisponivelTrue();
+        return ResponseEntity.ok(livros);
     }
 
     @PostMapping("/emprestar")
-    public String emprestarLivro(@RequestParam String titulo) {
-        return emprestimoService.emprestarLivro(titulo);
+    public ResponseEntity<String> emprestarLivro(@RequestParam String titulo) {
+        EmprestimoStatus status = emprestimoService.emprestarLivro(titulo);
+
+        return switch (status) {
+            case SUCESSO -> ResponseEntity.ok("Livro emprestado: " + titulo);
+            case LIVRO_NAO_ENCONTRADO -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("Livro não encontrado.");
+            case LIVRO_JA_EMPRESTADO -> ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("Livro já foi emprestado.");
+            default -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("");
+        };
+    }
+
+    @PostMapping("/devolver")
+    public ResponseEntity<String> devolverLivro(@RequestParam String titulo) {
+        EmprestimoStatus status = emprestimoService.devolverLivro(titulo);
+
+        return switch (status) {
+            case SUCESSO -> ResponseEntity.ok("Livro devolvido: " + titulo);
+            case LIVRO_NAO_ENCONTRADO -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("Livro não encontrado.");
+            case LIVRO_JA_DEVOLVIDO -> ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("Livro já foi devolvido.");
+            default -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("");
+        };
     }
 }

--- a/src/main/java/com/example/biblioteca_spring/service/EmprestimoService.java
+++ b/src/main/java/com/example/biblioteca_spring/service/EmprestimoService.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+/**
+ * Serviço responsável por emprestar e devolver livros.
+ */
+
 @Service
 public class EmprestimoService {
 
@@ -17,20 +21,43 @@ public class EmprestimoService {
         this.livroRepository = livroRepository;
     }
 
-    public String emprestarLivro(String titulo) {
+    /**
+     * Tenta emprestar um livro pelo título.
+     */
+    public EmprestimoStatus emprestarLivro(String titulo) {
         Optional<Livro> livroOptional = livroRepository.findByTitulo(titulo);
 
-        if (livroOptional.isPresent()) {
-            Livro livro = livroOptional.get();
-            if (livro.isDisponivel()) {
-                livro.setDisponivel(false);
-                livroRepository.save(livro);
-                return "Livro emprestado: " + titulo;
-            } else {
-                return "Livro já foi emprestado.";
-            }
-        } else {
-            return "Livro não disponível ou não encontrado.";
+        if (livroOptional.isEmpty()) {
+            return EmprestimoStatus.LIVRO_NAO_ENCONTRADO;
         }
+
+        Livro livro = livroOptional.get();
+        if (!livro.isDisponivel()) {
+            return EmprestimoStatus.LIVRO_JA_EMPRESTADO;
+        }
+
+        livro.setDisponivel(false);
+        livroRepository.save(livro);
+        return EmprestimoStatus.SUCESSO;
+    }
+
+    /**
+     * Tenta devolver um livro pelo título.
+     */
+    public EmprestimoStatus devolverLivro(String titulo) {
+        Optional<Livro> livroOptional = livroRepository.findByTitulo(titulo);
+
+        if (livroOptional.isEmpty()) {
+            return EmprestimoStatus.LIVRO_NAO_ENCONTRADO;
+        }
+
+        Livro livro = livroOptional.get();
+        if (livro.isDisponivel()) {
+            return EmprestimoStatus.LIVRO_JA_DEVOLVIDO;
+        }
+
+        livro.setDisponivel(true);
+        livroRepository.save(livro);
+        return EmprestimoStatus.SUCESSO;
     }
 }

--- a/src/main/java/com/example/biblioteca_spring/service/EmprestimoStatus.java
+++ b/src/main/java/com/example/biblioteca_spring/service/EmprestimoStatus.java
@@ -1,0 +1,11 @@
+package com.example.biblioteca_spring.service;
+
+/**
+ * Representa o resultado de uma operação de empréstimo ou devolução de livro.
+ */
+public enum EmprestimoStatus {
+    SUCESSO,
+    LIVRO_NAO_ENCONTRADO,
+    LIVRO_JA_EMPRESTADO,
+    LIVRO_JA_DEVOLVIDO
+}


### PR DESCRIPTION
## Summary
- return `ResponseEntity` in controller
- add new `/devolver` endpoint
- handle loan logic via new `EmprestimoStatus`

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68499c3e84408331a88cb45a51b0b5b9